### PR TITLE
build-bottle-pr: check for open PRs

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -25,6 +25,14 @@ module Homebrew
     @tap_dir ||= ARGV.value("tap-dir") || "/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core"
   end
 
+  # Check if pull request is already opened.
+  def hub_pr_already_opened?(title)
+    `hub pr list --format '%t%n'`.each_line do |line|
+      return true if line.chomp == title
+    end
+    false
+  end
+
   # Open a pull request using hub.
   def hub_pull_request(formula, remote, branch, message)
     ohai "#{formula}: Using remote '#{remote}' to submit Pull Request" if ARGV.verbose?
@@ -53,6 +61,8 @@ module Homebrew
     branch = "bottle-#{formula}"
     cd tap_dir do
       formula_path = "Formula/#{formula}.rb"
+      return odie "#{formula}: PR already exists" if hub_pr_already_opened?(title)
+
       unless Utils.popen_read("git", "branch", "--list", branch).empty?
         return odie "#{formula}: Branch #{branch} already exists" unless ARGV.force?
 

--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -29,23 +29,11 @@ module Homebrew
     (tap.official? && !x.nil?) ? x.capitalize : x
   end
 
-  def open_pull_request?(formula)
-    prs = GitHub.issues_for_formula(formula,
-      type: "pr", state: "open", repo: slug(formula.tap))
-    prs = prs.select { |pr| pr["title"].start_with? "#{formula}: " }
-    if prs.any? && ARGV.verbose?
-      opoo "#{formula}: Skipping because a PR is open"
-      prs.each { |pr| ohai "#{pr["title"]} (#{pr["html_url"]})" }
-    end
-    prs.any?
-  end
-
   def should_not_build_linux_bottle?(formula, tag)
     formula.bottle_unneeded? || \
       formula.bottle_disabled? || \
       formula.bottle_specification.tag?(tag) || \
-      slug(formula.tap) == "Homebrew/homebrew-core" || \
-      open_pull_request?(formula)
+      slug(formula.tap) == "Homebrew/homebrew-core"
   end
 
   def reason_to_not_build_bottle(formula, tag)
@@ -53,7 +41,6 @@ module Homebrew
     return opoo "#{formula}: Skipping because bottles are disabled" if formula.bottle_disabled?
     return opoo "#{formula}: Skipping because it has a bottle already" if formula.bottle_specification.tag?(tag)
     return opoo "#{formula}: Skipping because #{formula.tap} does not support Linux" if slug(formula.tap) == "Homebrew/homebrew-core"
-    return if open_pull_request?(formula)
   end
 
   formulae_to_bottle = []


### PR DESCRIPTION
I think it could be a nice failsafe, to first check if a PR is already opened with given title.

Also the `--force` option would need to be redefined as: 'when passed, do not check for opened PRs' and the branch deletion would become the default then.