### PR TITLE
build-bottle-pr: Use "Linux" instead of "Linuxbrew"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 Tools for Homebrew on Linux developers
 
-+ **build-bottle-pr**: Submit a pull request to build a bottle for Linuxbrew
++ **build-bottle-pr**: Submit a pull request to build a bottle for Linux
++ **find-formulae-to-bottle**: For a merge commit, generate a list of conflicting formulae
 + **merge-homebrew**: Merge a tap Homebrew/repo into Linuxbrew/repo
-+ **pull-bottle**: Merge a pull request and update both the Mac and Linux bottles
-+ **pull-linux**: Merge a pull request and update the Linuxbrew bottle
 + **squash-bottle-pr**: Squash the last two commits created by build-bottle-pr
 
 ## Installation

--- a/cmd/brew-announce.rb
+++ b/cmd/brew-announce.rb
@@ -8,9 +8,9 @@ module Homebrew
     contents = formula.path.read
     cite = contents[/# cite .*"(.*)"/, 1]
 
-    os = if contents =~ /depends_on :linux$/
+    os = if contents.match?(/depends_on :linux$/)
       "Linux"
-    elsif contents =~ /depends_on :macos$/
+    elsif contents.match?(/depends_on :macos$/)
       "macOS"
     else
       "Linux and macOS"

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -4,7 +4,7 @@
 #:    If `--remote` is passed, use the specified GitHub remote. Otherwise, use `origin`.
 #:    If `--dry-run` is passed, do not actually make any PR's.
 #:    If `--verbose` is passed, print extra information.
-#:    If `--tap-dir` is passed, use the specified full path to a tap. Otherwise, use the Linuxbrew standard install location.
+#:    If `--tap-dir` is passed, use the specified full path to a tap. Otherwise, use the Homebrew on Linux standard install location.
 #:    If `--force` is passed, delete local and remote 'bottle-<name>' branches if they exist. Use with care.
 #:    If `--browse` is passed, open a web browser for the new pull request.
 
@@ -41,7 +41,7 @@ module Homebrew
   end
 
   def build_bottle(formula)
-    title = "#{formula}: Build a bottle for Linuxbrew"
+    title = "#{formula}: Build a bottle for Linux"
     message = <<~EOS
       #{title}
 

--- a/cmd/brew-squash-bottle-pr.rb
+++ b/cmd/brew-squash-bottle-pr.rb
@@ -9,7 +9,7 @@ module Homebrew
   #    brew pull --bottle 123
   #    brew squash-bottle-pr
   def squash_bottle_pr
-    unless Utils.popen_read("git", "log", "-n1", "--pretty=%s", "HEAD~1").match?(/: Build a bottle for Linuxbrew$/)
+    unless Utils.popen_read("git", "log", "-n1", "--pretty=%s", "HEAD~1").match?(/: Build a bottle for Linux$/)
       opoo "No build-bottle-pr commit was found"
       return
     end

--- a/cmd/brew-squash-bottle-pr.rb
+++ b/cmd/brew-squash-bottle-pr.rb
@@ -9,7 +9,7 @@ module Homebrew
   #    brew pull --bottle 123
   #    brew squash-bottle-pr
   def squash_bottle_pr
-    unless Utils.popen_read("git", "log", "-n1", "--pretty=%s", "HEAD~1") =~ /: Build a bottle for Linuxbrew$/
+    unless Utils.popen_read("git", "log", "-n1", "--pretty=%s", "HEAD~1").match?(/: Build a bottle for Linuxbrew$/)
       opoo "No build-bottle-pr commit was found"
       return
     end
@@ -32,7 +32,7 @@ module Homebrew
 
     safe_system "git", "show" if ARGV.verbose?
 
-    if Utils.popen_read("git", "log", "-n1", "--pretty=%s", "HEAD~1") =~ /^drop! /
+    if Utils.popen_read("git", "log", "-n1", "--pretty=%s", "HEAD~1").match?(/^drop! /)
       bottle_head = Utils.popen_read("git", "rev-parse", "HEAD").chomp
       safe_system "git", "reset", "--hard", "HEAD~2"
       safe_system "git", "cherry-pick", bottle_head


### PR DESCRIPTION
- We're moving away from the Linuxbrew name to Homebrew on Linux. Most
  of our docs say Homebrew on Linux. Linuxbrew _feels weird_ especially
  in bottle PRs.