### PR TITLE
azure-pipelines: rework

### DIFF
--- a/.github/workflows/check_style.yml
+++ b/.github/workflows/check_style.yml
@@ -1,0 +1,21 @@
+name: Check style
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: homebrew/brew
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Update
+        run: brew update-reset $(brew --repository)
+      - name: Test
+        run: brew style $GITHUB_REPOSITORY

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
         sudo cp -a $(Build.Repository.LocalPath) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-linux-dev
       displayName: Set up tap
     - bash: |
-        /home/linuxbrew/.linuxbrew/bin/brew style $BUILD_REPOSITORY_ID
+        sudo -E /home/linuxbrew/.linuxbrew/bin/brew style $BUILD_REPOSITORY_ID
       displayName: Run brew style
       env:
         HOMEBREW_NO_AUTO_UPDATE: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,10 @@ jobs:
     image: homebrew/brew:latest
   steps:
     - bash: |
+        git config --global user.name LinuxbrewTestBot
+        git config --global user.email testbot@linuxbrew.sh
+      displayName: Configure git
+    - bash: |
         git fetch origin "master:master" "pull/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/head:pr"
         git checkout pr
       condition: ne(variables['System.PullRequest.PullRequestNumber'], '')
@@ -13,6 +17,11 @@ jobs:
     - bash: |
         sudo cp -a $(Build.Repository.LocalPath) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-linux-dev
       displayName: Set up tap
+    - bash: |
+        cd /home/linuxbrew/.linuxbrew/Homebrew
+        sudo git fetch origin --tags
+        sudo git reset --hard origin/master
+      displayName: Update Homebrew
     - bash: |
         sudo -E /home/linuxbrew/.linuxbrew/bin/brew style $BUILD_REPOSITORY_ID
       displayName: Run brew style

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 jobs:
-- job: Check style of commands
+- job: CheckStyle
   pool:
     vmImage: ubuntu-16.04
   container:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,30 +1,20 @@
 jobs:
-- job: Linux
+- job: Check style of commands
   pool:
     vmImage: ubuntu-16.04
+  container:
+    image: homebrew/brew:latest
   steps:
     - bash: |
-        set -ex
-        if [[ -n "$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" ]]; then
-          git fetch origin "master:master" "pull/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/head:pr"
-          git checkout pr
-        fi
-        set -u
-        sudo mkdir /home/linuxbrew
-        sudo chown "$USER" /home/linuxbrew
-        git config --global user.name LinuxbrewTestBot
-        git config --global user.email testbot@linuxbrew.sh
-        git clone https://github.com/Homebrew/brew /home/linuxbrew/.linuxbrew/Homebrew
-        mkdir /home/linuxbrew/.linuxbrew/bin
-        ln -s ../Homebrew/bin/brew /home/linuxbrew/.linuxbrew/bin/
-        tap=$(/home/linuxbrew/.linuxbrew/bin/brew --repo $BUILD_REPOSITORY_ID)
-        mkdir -p $(dirname "$tap")
-        ln -s "$PWD" "$tap"
+        git fetch origin "master:master" "pull/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/head:pr"
+        git checkout pr
+      condition: ne(variables['System.PullRequest.PullRequestNumber'], '')
+      displayName: Checkout pull request
+    - bash: |
+        sudo cp -a $(Build.Repository.LocalPath) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-linux-dev
+      displayName: Set up tap
+    - bash: |
         /home/linuxbrew/.linuxbrew/bin/brew style $BUILD_REPOSITORY_ID
-        /home/linuxbrew/.linuxbrew/bin/brew install patchelf
-        /home/linuxbrew/.linuxbrew/bin/brew test-bot --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh
-      displayName: Run brew test-bot
+      displayName: Run brew style
       env:
-        HOMEBREW_GITHUB_API_TOKEN: $(github.publicApiToken)
-        HOMEBREW_NO_ANALYTICS: 1
         HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
This is a rework of Azure pipelines config.
Major changes:
- run on `homebrew/brew` Docker image
- swap `if` bash condition with Azure condition
- copy checked out repo to Taps directory
- don't run `test-bot`, seemed redundant to me
- delete unused env variables
- reword `displayName`s
- update Homebrew itself before running `brew style`