### PR TITLE
find-formulae-to-bottle: do not check if depends on macos

### DIFF
--- a/cmd/brew-find-formulae-to-bottle.rb
+++ b/cmd/brew-find-formulae-to-bottle.rb
@@ -29,10 +29,6 @@ module Homebrew
     (tap.official? && !x.nil?) ? x.capitalize : x
   end
 
-  def depends_on_macos?(formula)
-    formula.requirements.any? { |req| (req.instance_of? MacOSRequirement) && !req.version_specified? }
-  end
-
   def open_pull_request?(formula)
     prs = GitHub.issues_for_formula(formula,
       type: "pr", state: "open", repo: slug(formula.tap))
@@ -45,13 +41,14 @@ module Homebrew
   end
 
   def should_not_build_linux_bottle?(formula, tag)
-    depends_on_macos?(formula) \
-      || formula.bottle_unneeded? || formula.bottle_disabled? || formula.bottle_specification.tag?(tag) \
-      || slug(formula.tap) == "Homebrew/homebrew-core" || open_pull_request?(formula)
+    formula.bottle_unneeded? || \
+      formula.bottle_disabled? || \
+      formula.bottle_specification.tag?(tag) || \
+      slug(formula.tap) == "Homebrew/homebrew-core" || \
+      open_pull_request?(formula)
   end
 
   def reason_to_not_build_bottle(formula, tag)
-    return opoo "#{formula}: Skipping because it depends on macOS" if depends_on_macos?(formula)
     return opoo "#{formula}: Skipping because a bottle is not needed" if formula.bottle_unneeded?
     return opoo "#{formula}: Skipping because bottles are disabled" if formula.bottle_disabled?
     return opoo "#{formula}: Skipping because it has a bottle already" if formula.bottle_specification.tag?(tag)


### PR DESCRIPTION
For example `go` formula has a line `depends_on :macos => :el_capitan`
even though it does not depend on macos and builds just fine on linux.

Also, if a formula is truly macOS only, then I guess we wouldn't get
any conflicts regarding these formulae, because we simply do not touch
them.