### PR TITLE
brew-check-for-deleted: support one repo workflow

### DIFF
--- a/cmd/brew-check-for-deleted-upstream-core-formulae.rb
+++ b/cmd/brew-check-for-deleted-upstream-core-formulae.rb
@@ -1,42 +1,48 @@
 #:  * `check-for-deleted-upstream-core-formulae` [`--homebrew-repo-dir`] [`--linuxbrew-repo-dir`]:
 #:    Outputs a list of formulae (with `.rb` suffix) for further `git rm` usage.
 #:
-#:    If `--linuxbrew-repo-dir` is passed, use the specified full path to the Homebrew/linuxbrew-core tap. Otherwise, use the Homebrew on Linux standard install location.
-#:    When `--homebrew-repo-dir` is passed, use the specified full path to the Homebrew/homebrew-core repo, or the `HOMEBREW_REPO_DIR` envvar.
+#:    If no arguments are passed, use master branch of core tap as Homebrew/linuxbrew-core repo and homebrew/master branch as Homebrew/homebrew-core repo.
+#:    If `--linuxbrew-repo-dir` is passed, use the specified full path to the Homebrew/linuxbrew-core repo. Otherwise, use the Homebrew on Linux standard install location.
+#:    When `--homebrew-repo-dir` is passed, use the specified full path to the Homebrew/homebrew-core repo. Otherwise, use the Homebrew on Linux standard install location.
 
 module Homebrew
   module_function
 
-  def homebrew_repo_dir
-    @homebrew_repo_dir ||= ARGV.value("homebrew-repo-dir") || ENV["HOMEBREW_REPO_DIR"]
-  end
-
-  def linuxbrew_repo_dir
-    @linuxbrew_repo_dir ||= ARGV.value("linuxbrew-repo-dir") || "/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core"
+  def git?
+    homebrew_repo_dir == linuxbrew_repo_dir
   end
 
   def linux_only?(formula)
-    File.open("#{linuxbrew_repo_dir}/Formula/#{formula}").grep("# tag \"linux").any?
+    File.read("#{linuxbrew_repo_dir}/Formula/#{formula}").match("# tag \"linux\"")
+  end
+
+  def homebrew_repo_dir
+    @homebrew_repo_dir ||= ARGV.value("homebrew-repo-dir") || CoreTap.instance.path
+  end
+
+  def linuxbrew_repo_dir
+    @linuxbrew_repo_dir ||= ARGV.value("linuxbrew-repo-dir") || CoreTap.instance.path
   end
 
   def homebrew_core_formulae
-    @homebrew_core_formulae ||= Dir.entries("#{homebrew_repo_dir}/Formula").reject! { |f| File.directory?(f) }.sort
+    quiet_system("git", "-C", homebrew_repo_dir, "checkout", "homebrew/master") if git?
+    formulae = Dir.entries("#{homebrew_repo_dir}/Formula").reject! { |f| File.directory?(f) }.sort
+    quiet_system("git", "-C", homebrew_repo_dir, "checkout", "-") if git?
+    formulae
   end
 
   def linuxbrew_core_formulae
-    @linuxbrew_core_formulae ||= Dir.entries("#{linuxbrew_repo_dir}/Formula").reject! { |f| File.directory?(f) }.sort
+    quiet_system("git", "-C", homebrew_repo_dir, "checkout", "master") if git?
+    formulae = Dir.entries("#{linuxbrew_repo_dir}/Formula").reject! { |f| File.directory?(f) || linux_only?(f) }.sort
+    quiet_system("git", "-C", homebrew_repo_dir, "checkout", "-") if git?
+    formulae
   end
 
-  def formulae_only_in_linuxbrew
-    [linuxbrew_core_formulae - homebrew_core_formulae].flatten.reject! { |formula| linux_only?(formula) }
-  end
-
-  odie "Specify the location of Homebrew/homebrew-core on your machine with `--homebrew-repo-dir` or `HOMEBREW_REPO_DIR`." unless homebrew_repo_dir
-
-  if formulae_only_in_linuxbrew
-    ohai "These formulae need deleting from Homebrew/linuxbrew-core:"
-    formulae_only_in_linuxbrew.each { |formula| puts formula }
-  else
+  formulae_only_in_linuxbrew = linuxbrew_core_formulae - homebrew_core_formulae
+  if formulae_only_in_linuxbrew.empty?
     ohai "No formulae need deleting."
+  else
+    ohai "These formulae need deleting from Homebrew/linuxbrew-core:"
+    puts formulae_only_in_linuxbrew
   end
 end


### PR DESCRIPTION
With this change, it is possible to make use of `homebrew/master` branch (which we already have set up for merges).

If no parameters are passed to the script, it checks out `homebrew/master` branch to get the list of available formulae in `homebrew-core`, then switches to `master` to get the list of formulae from `linuxbrew-core` while excluding those linux specific ones.

I tried not to break the existing functionality and it seems to be kept.