### PR TITLE
cmd/brew-build-bottle-pr.rb: sync with description

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -18,7 +18,7 @@ module Homebrew
   end
 
   def remote
-    @remote ||= ARGV.value("remote") || ENV["HOMEBREW_GITHUB_USER"]
+    @remote ||= ARGV.value("remote") || ENV["HOMEBREW_GITHUB_USER"] || "origin"
   end
 
   def tap_dir


### PR DESCRIPTION
The description says that `remote` defaults to `origin` but the code says otherwise. Here, I'm syncing code with description since it makes sense for `remote` to default to `origin`.