### PR TITLE
brew-build-bottle-pr.rb: assorted fixes

### DIFF
--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -49,9 +49,9 @@ module Homebrew
   end
 
   def remote_user(remote)
-    url = Utils.popen_read("git", "remote", "get-url", remote).chomp()
+    url = Utils.popen_read("git", "remote", "get-url", remote).chomp
     match = url.match(%r{github\.com.(.+)/})
-    return match[1]
+    match[1]
   end
 
   def build_bottle(formula)
@@ -100,7 +100,7 @@ module Homebrew
     ENV["HOMEBREW_DISABLE_LOAD_FORMULA"] = "1"
 
     odie "'HOMEBREW_GITHUB_API_TOKEN' is unset." unless ENV["HOMEBREW_GITHUB_API_TOKEN"]
-    odie "'HOMEBREW_GITHUB_USER' is unset." unless (ENV["HOMEBREW_GITHUB_USER"] || ENV["USER"] != "linuxbrew")
+    odie "'HOMEBREW_GITHUB_USER' is unset." unless ENV["HOMEBREW_GITHUB_USER"] || ENV["USER"] != "linuxbrew"
     odie "Please install hub (brew install hub) before proceeding" unless which "hub"
     odie "No formula has been specified" unless formula
     odie "No remote has been specified: use `--remote=origin` or `--remote=$HOMEBREW_GITHUB_USER`" unless remote

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -49,9 +49,7 @@ module Homebrew
   end
 
   def remote_user(remote)
-    url = Utils.popen_read("git", "remote", "get-url", remote).chomp
-    match = url.match(%r{github\.com.(.+)/})
-    match[1]
+    Utils.popen_read("git", "remote", "get-url", remote)[%r{github\.com[/:]([^/]+)/}, 1]
   end
 
   def build_bottle(formula)


### PR DESCRIPTION
1. Check that HOMEBREW_GITHUB_API_TOKEN is set and assign GITHUB_TOKEN to it.
Otherwise, `hub` commands stall.

2. Check that HOMEBREW_GITHUB_USER is set if USER is set to 'linuxbrew'.
When assigning an assignee to the created PR, we can't use 'linuxbrew'.
It has to be the person running the command. Therefore, if HOMEBREW_GITHUB_USER is unset,
we have to make sure that we're not running in a homebrew/brew container or ask the developer
to set HOMEBREW_GITHUB_USER.

3. When specifying a HEAD branch with `hub`, we have to specify OWNER:branch.
Previously, the syntax was `remote:branch`, which does not work unless remote name is equal
to user/org name on GitHub. Here, I'm introducing a remote_user function that extracts username
for the specified remote and uses it for creating a pull request.