### PR TITLE
workflow: mkdir directory before copying to it

### DIFF
--- a/.github/workflows/check_style.yml
+++ b/.github/workflows/check_style.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Update
         run: brew update-reset "$(brew --repository)"
       - name: Setup
-        run: cp -a "$PWD" "$(brew --repository ${{github.repository}})"
+        run: |
+          mkdir -p "$(dirname $(brew --repository ${{github.repository}}))"
+          cp -a "$PWD" "$(brew --repository ${{github.repository}})"
       - name: Test
         run: brew style "${{github.repository}}"


### PR DESCRIPTION
Should fix the situation, where workflow job would fail, when run in a
repo fork, because of non-existent directory.