### PR TITLE
Revert "Switch from using ARGV to Homebrew.args"

### DIFF
--- a/cmd/brew-announce.rb
+++ b/cmd/brew-announce.rb
@@ -1,16 +1,8 @@
-require "cli/parser"
+#:  * `announce` <formulae>:
+#:    Create an announcement for new formulae.
 
 module Homebrew
   module_function
-
-  def announce_args
-    Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS
-        `announce` <formulae>
-        Create an announcement for new formulae.
-      EOS
-    end
-  end
 
   def announce_formula(formula)
     contents = formula.path.read
@@ -39,11 +31,9 @@ module Homebrew
   end
 
   def announce_formulae
-    announce_args.parse
+    raise FormulaUnspecifiedError if ARGV.named.empty?
 
-    raise FormulaUnspecifiedError if Homebrew.args.named.empty?
-
-    Homebrew.args.resolved_formulae.each do |formula|
+    ARGV.resolved_formulae.each do |formula|
       announce_formula formula
     end
   end

--- a/cmd/brew-build-bottle-pr.rb
+++ b/cmd/brew-build-bottle-pr.rb
@@ -1,39 +1,28 @@
-require "cli/parser"
+#:  * `build-bottle-pr` [`--remote=<user>`] [`--dry-run`] [`--verbose`] [`--tap-dir`] [`--force`]:
+#:    Submit a pull request to build a bottle for a formula.
+#:
+#:    If `--remote` is passed, use the specified GitHub remote. Otherwise, use `origin`.
+#:    If `--dry-run` is passed, do not actually make any PR's.
+#:    If `--verbose` is passed, print extra information.
+#:    If `--tap-dir` is passed, use the specified full path to a tap. Otherwise, use the Homebrew on Linux standard install location.
+#:    If `--force` is passed, delete local and remote 'bottle-<name>' branches if they exist. Use with care.
+#:    If `--browse` is passed, open a web browser for the new pull request.
+
 require "English"
 
 module Homebrew
   module_function
-
-  def build_bottle_pr_args
-    Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS
-        `build-bottle-pr` [`--remote=<user>`] [`--dry-run`] [`--verbose`] [`--tap-dir`] [`--force`]
-        Submit a pull request to build a bottle for a formula.
-      EOS
-      flag "--remote",
-           description: "Use the specified GitHub remote. Otherwise, use `origin`."
-      flag "--tap-dir",
-           description: "Use the specified full path to a tap. Otherwise, use the Homebrew on Linux standard install location."
-      switch "--browse",
-             description: "Open a web browser for the pull request."
-      switch "--dry-run",
-             description: "Do not actually raise any pull requests."
-      switch "--force",
-             description: "Delete local and remote 'bottle-<formula>' branches if they exist. Use with care."
-      switch :verbose
-    end
-  end
 
   def formula
     @formula ||= ARGV.last.to_s
   end
 
   def remote
-    @remote ||= Homebrew.args.remote || ENV["HOMEBREW_GITHUB_USER"] || origin
+    @remote ||= ARGV.value("remote") || ENV["HOMEBREW_GITHUB_USER"] || "origin"
   end
 
   def tap_dir
-    @tap_dir ||= Homebrew.args.tap_dir || "/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core"
+    @tap_dir ||= ARGV.value("tap-dir") || "/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core"
   end
 
   # Check if pull request is already opened.
@@ -46,7 +35,7 @@ module Homebrew
 
   # Open a pull request using hub.
   def hub_pull_request(formula, remote, branch, message)
-    ohai "#{formula}: Using remote '#{remote}' to submit Pull Request" if Homebrew.args.verbose?
+    ohai "#{formula}: Using remote '#{remote}' to submit Pull Request" if ARGV.verbose?
     safe_system "git", "push", remote, branch
     args = []
     hub_version = Version.new(Utils.popen_read("hub", "--version")[/hub version ([0-9.]+)/, 1])
@@ -55,7 +44,7 @@ module Homebrew
     else
       opoo "Please upgrade hub\n  brew upgrade hub"
     end
-    args << "--browse" if Homebrew.args.browse?
+    args << "--browse" if ARGV.include? "--browse"
     safe_system "hub", "pull-request", "-h", "#{remote}:#{branch}", "-m", message, *args
   end
 
@@ -75,23 +64,23 @@ module Homebrew
       return odie "#{formula}: PR already exists" if hub_pr_already_opened?(title)
 
       unless Utils.popen_read("git", "branch", "--list", branch).empty?
-        return odie "#{formula}: Branch #{branch} already exists" unless Homebrew.args.force?
+        return odie "#{formula}: Branch #{branch} already exists" unless ARGV.include? "--force"
 
-        ohai "#{formula}: Removing branch #{branch} in #{tap_dir}" if Homebrew.args.verbose?
+        ohai "#{formula}: Removing branch #{branch} in #{tap_dir}" if ARGV.verbose?
         safe_system "git", "branch", "-D", branch
       end
       safe_system "git", "checkout", "-b", branch, "master"
       File.open(formula_path, "r+") do |f|
         s = f.read
         f.rewind
-        f.write "# #{title}\n#{s}" unless Homebrew.args.dry_run?
+        f.write "# #{title}\n#{s}" if ARGV.value("dry_run").nil?
       end
-      unless Homebrew.args.dry_run?
+      if ARGV.value("dry_run").nil?
         safe_system "git", "commit", formula_path, "-m", title
         unless Utils.popen_read("git", "branch", "-r", "--list", "#{remote}/#{branch}").empty?
-          return odie "#{formula}: Remote branch #{remote}/#{branch} already exists" unless Homebrew.args.force?
+          return odie "#{formula}: Remote branch #{remote}/#{branch} already exists" unless ARGV.include? "--force"
 
-          ohai "#{formula}: Removing branch #{branch} from #{remote}" if Homebrew.args.verbose?
+          ohai "#{formula}: Removing branch #{branch} from #{remote}" if ARGV.verbose?
           safe_system "git", "push", "--delete", remote, branch
         end
         hub_pull_request formula, remote, branch, message
@@ -102,8 +91,6 @@ module Homebrew
   end
 
   def build_bottle_pr
-    build_bottle_pr_args.parse
-
     ENV["HOMEBREW_DISABLE_LOAD_FORMULA"] = "1"
 
     odie "Please install hub (brew install hub) before proceeding" unless which "hub"

--- a/cmd/brew-migrate-formula.rb
+++ b/cmd/brew-migrate-formula.rb
@@ -1,29 +1,14 @@
-require "cli/parser"
+#:  * `migrate-formula` [--remote=<remote>] [--tap=<tap>] <formulae>:
+#:    Migrate formulae to a new tap.
+#:
+#:    --remote=<remote> Use this GitHub remote, or $HOMEBREW_GITHUB_USER or $USER.
+#:    --tap=<tap> Move formulae to this tap.
 
 module Homebrew
   module_function
 
-  def migrate_formula_args
-    Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS
-        `migrate-formula` [--remote=<remote>] [--tap=<tap>] <formulae>
-        Migrate formulae to a new tap.
-      EOS
-      flag "--remote",
-            description: "Use this GitHub remote, or $HOMEBREW_GITHUB_USER or $USER."
-      flag "--tap",
-            description: "Move formulae to this tap."
-      switch "--skip-style",
-             description: "Skip running `brew style` on the formula."
-      switch "--skip-audit",
-             description: "Skip running `brew audit` on the formula."
-      switch "--skip-install",
-             description: "Skip installing the formula."
-    end
-  end
-
   def remote
-    Homebrew.args.remote || ENV["HOMEBREW_GITHUB_USER"] || ENV["USER"]
+    ARGV.value("remote") || ENV["HOMEBREW_GITHUB_USER"] || ENV["USER"]
   end
 
   def open_pull_request?(formula, tap)
@@ -64,9 +49,9 @@ module Homebrew
     with_homebrew_path { safe_system *which_editor.split, dest }
 
     full_name = "#{tap}/#{formula.name}"
-    safe_system HOMEBREW_BREW_FILE, "style", full_name unless Homebrew.args.skip_style?
-    safe_system HOMEBREW_BREW_FILE, "install", "-s", full_name unless Homebrew.args.skip_install?
-    safe_system HOMEBREW_BREW_FILE, "audit", "--new-formula", full_name unless Homebrew.args.skip_audit?
+    safe_system HOMEBREW_BREW_FILE, "style", full_name unless ARGV.include? "--skip-style"
+    safe_system HOMEBREW_BREW_FILE, "install", "-s", full_name unless ARGV.include? "--skip-install"
+    safe_system HOMEBREW_BREW_FILE, "audit", "--new-formula", full_name unless ARGV.include? "--skip-audit"
 
     cd dest.dirname do
       branch = "migrate-#{formula.name}"
@@ -117,7 +102,7 @@ module Homebrew
   end
 
   def migrate_formula(formula)
-    tap = Tap.new *(Homebrew.args.tap || "homebrew/core").split("/")
+    tap = Tap.new *(ARGV.value("tap") || "homebrew/core").split("/")
     if formula.tap.to_s == tap.to_s
       opoo "#{formula.name} is already in #{tap}"
       return
@@ -129,11 +114,9 @@ module Homebrew
   end
 
   def migrate_formulae
-    migrate_formula_args.parse
+    raise FormulaUnspecifiedError if ARGV.named.empty?
 
-    raise FormulaUnspecifiedError if Homebrew.args.named.empty?
-
-    Homebrew.args.resolved_formulae.each do |formula|
+    ARGV.resolved_formulae.each do |formula|
       migrate_formula formula
     end
   end

--- a/cmd/brew-test-bot-docker.rb
+++ b/cmd/brew-test-bot-docker.rb
@@ -3,29 +3,15 @@
 #:  Build a bottle for the specified formulae using a Docker container.
 #:  See `test-bot` for further options accepted by this command.
 
-require "cli/parser"
-
 module Homebrew
   module_function
 
-  def test_bot_docker_args
-    Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS
-        `test-bot-docker` <formulae>
-        Build a bottle for the specified formulae using a Docker container.
-        Runs `brew test-bot` with options.
-      EOS
-    end
-  end
-
   def test_bot_docker
-    test_bot_docker_args.parse
-
     if ENV["HOMEBREW_BINTRAY_USER"].nil? || ENV["HOMEBREW_BINTRAY_KEY"].nil?
       raise "Missing HOMEBREW_BINTRAY_USER or HOMEBREW_BINTRAY_KEY variables!"
     end
 
-    formulae = Homebrew.args.named
+    argv = ARGV.join(" ")
     safe_system "docker", "run", "--name=linuxbrew-test-bot",
       "-e", "HOMEBREW_BINTRAY_USER", "-e", "HOMEBREW_BINTRAY_KEY",
       "homebrew/brew",
@@ -35,7 +21,7 @@ module Homebrew
         brew tap linuxbrew/xorg
         mkdir linuxbrew-test-bot
         cd linuxbrew-test-bot
-        brew test-bot #{formulae.join(" ")}
+        brew test-bot #{argv}
         status=$?
         ls
         brew test-bot --ci-upload --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh


### PR DESCRIPTION
Reverts Homebrew/homebrew-linux-dev#137

The fix for the `--help` text was reverted in https://github.com/Homebrew/brew/pull/6988  and I don't know how much time fixing the broken thing mentioned there will take.