### PR TITLE
request-bottle: include user and email in payload

### DIFF
--- a/cmd/request-bottle.rb
+++ b/cmd/request-bottle.rb
@@ -15,14 +15,22 @@ module Homebrew
     end
   end
 
+  def git_user
+    ENV["HOMEBREW_GIT_NAME"] || ENV["GIT_AUTHOR_NAME"] || ENV["GIT_COMMITTER_NAME"] || Utils.popen_read(Utils.git_path, "config", "--get", "user.name").strip
+  end
+
+  def git_email
+    ENV["HOMEBREW_GIT_EMAIL"] || ENV["GIT_AUTHOR_EMAIL"] || ENV["GIT_COMMITTER_EMAIL"] || Utils.popen_read(Utils.git_path, "config", "--get", "user.email").strip
+  end
+
   def request_bottle
     request_bottle_args.parse
 
     raise FormulaUnspecifiedError if Homebrew.args.named.empty?
 
     formula = Homebrew.args.resolved_formulae.last.full_name
-
-    data = { event_type: "bottling", client_payload: { formula: formula } }
+    payload = { formula: formula, name: git_user, email: git_email }
+    data = { event_type: "bottling", client_payload: payload }
     url = "https://api.github.com/repos/Homebrew/linuxbrew-core/dispatches"
     GitHub.open_api(url, data: data, request_method: :POST, scopes: ["repo"])
   end


### PR DESCRIPTION
Includes the user and email of the person requesting the bottle, for use in the commit workflow on Homebrew/linuxbrew-core.