### PR TITLE
find-not-bottled: Exclude formulae that depend on XCode

### DIFF
--- a/cmd/find-not-bottled.rb
+++ b/cmd/find-not-bottled.rb
@@ -27,6 +27,7 @@ module Homebrew
 
     must_not_find = [
       /bottle :unneeded/,
+      /depends_on :xcode/,
       /:x86_64_linux/,
       Homebrew.args.must_not_find,
     ].compact


### PR DESCRIPTION
- We can't build them on Linux.
- Not using `depends_on :macos` because there are some that _do_ work.