### PR TITLE
check-deleted-upstream-formulae: Fix Linux-only formula detection

### DIFF
--- a/cmd/check-for-deleted-upstream-core-formulae.rb
+++ b/cmd/check-for-deleted-upstream-core-formulae.rb
@@ -25,7 +25,7 @@ module Homebrew
   end
 
   def linux_only?(formula)
-    File.read("#{linuxbrew_repo_dir}/Formula/#{formula}").match("# tag \"linux\"")
+    File.read("#{linuxbrew_repo_dir}/Formula/#{formula}").match("depends_on :linux")
   end
 
   def homebrew_repo_dir


### PR DESCRIPTION
- Since https://github.com/Homebrew/linuxbrew-core/commit/6578a4aa86b80816cf0553f1d45828c0072197a4, we're using the proper `depends_on` DSL to specify Linux-only formulae.