### PR TITLE
add pull-macos script

### DIFF
--- a/cmd/pull-macos.rb
+++ b/cmd/pull-macos.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "dev-cmd/pull"
+
+module Homebrew
+  module_function
+
+  ENV["HOMEBREW_BOTTLE_DOMAIN"] = "https://homebrew.bintray.com"
+  ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] = "1"
+
+  def pull_macos_args
+    Homebrew.pull_args
+  end
+
+  def pull_macos
+    Homebrew.pull
+  end
+
+  def merge_commit?(url)
+    pr_number = url[%r{/pull\/([0-9]+)}, 1]
+    return false unless pr_number
+
+    safe_system "git", "fetch", "--quiet", "homebrew", "pull/#{pr_number}/head"
+    Utils.popen_read("git", "rev-list", "--parents", "-n1", "FETCH_HEAD").count(" ") > 1
+  end
+end


### PR DESCRIPTION
Tried to apply this upstream: https://github.com/Homebrew/brew/pull/7070
But it got reverted, because of some issues with Jenkins: https://github.com/Homebrew/brew/pull/7077

- `merge_commit?` function needed to be overridden with one small change: `origin` -> `homebrew`.
- `HOMEBREW_BOTTLE_DOMAIN` needs to be set again here, because it's only set in `brew.sh` earlier

I'm using this script right now, to pull some bottles and it works fine.
`brew pull-macos PR_NUMBER`