### PR TITLE
merge-homebrew: Make skipping `brew style` the default

### DIFF
--- a/cmd/merge-homebrew.rb
+++ b/cmd/merge-homebrew.rb
@@ -18,8 +18,8 @@ module Homebrew
              description: "Merge Homebrew/tap into user/tap."
       switch "--browse",
              description: "Open a web browser for the pull request."
-      switch "--skip-style",
-             description: "Skip running `brew style` on merged formulae."
+      switch "--style",
+             description: "Run `brew style` on merged formulae."
       conflicts "--core", "--tap"
       max_named 1
     end
@@ -74,7 +74,7 @@ module Homebrew
     else
       safe_system(*editor, *conflicts)
     end
-    safe_system HOMEBREW_BREW_FILE, "style", *conflicts unless Homebrew.args.skip_style?
+    safe_system HOMEBREW_BREW_FILE, "style", *conflicts if Homebrew.args.style?
     safe_system git, "diff", "--check"
     safe_system git, "add", "--", *conflicts
     conflicts

--- a/cmd/merge-homebrew.rb
+++ b/cmd/merge-homebrew.rb
@@ -129,6 +129,8 @@ module Homebrew
         puts deleted_files
       end
 
+      safe_system("brew", "readall", "--aliases")
+
       hub_pull_request branch, message
     end
   end


### PR DESCRIPTION
- In all my time working on Homebrew, I've never *not* appended `--skip-style` to my `brew merge-homebrew --core` commands.
- Therefore, this makes *not* running `brew style` be the default as it feels weird to *always* specify skipping something.