### PR TITLE
request-bottle: use better event names

### DIFF
--- a/cmd/request-bottle.rb
+++ b/cmd/request-bottle.rb
@@ -57,12 +57,15 @@ module Homebrew
     odie "Email not specified" if email.empty?
 
     Homebrew.args.resolved_formulae.each do |formula|
+      event_name = formula.name.to_s
+      event_name += " (##{Homebrew.args.issue})" if Homebrew.args.issue
+
       payload = { formula:       formula.name,
                   name:          user,
                   email:         email,
                   ignore_errors: Homebrew.args.ignore_errors?,
                   issue:         Homebrew.args.issue || 0 }
-      data = { event_type: "bottling", client_payload: payload }
+      data = { event_type: event_name, client_payload: payload }
       url = "https://api.github.com/repos/Homebrew/linuxbrew-core/dispatches"
       GitHub.open_api(url, data: data, request_method: :POST, scopes: ["repo"])
     end


### PR DESCRIPTION
This shows up in the Actions tab, so it should be easier to scan for what you're looking for in the case where you're looking for a build that test bot didn't ping you for.

![Screen Shot 2020-03-22 at 02 43 18](https://user-images.githubusercontent.com/213484/77230274-38a24f00-6be7-11ea-9d87-1146df7cba6d.png)
