### PR TITLE
add fetch-failed-logs script

### DIFF
--- a/cmd/fetch-failed-logs.rb
+++ b/cmd/fetch-failed-logs.rb
@@ -1,0 +1,113 @@
+require "cli/parser"
+require "utils/github"
+
+module Homebrew
+  module_function
+
+  def fetch_failed_logs_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `fetch-failed-logs` [<options>] <formula>
+
+        Fetch failed job logs from GitHub Actions workflow run.
+
+        By default searches through workflow runs triggered by pull_request event.
+      EOS
+      switch "--dispatched",
+        description: "Search through workflow runs triggered by repository_dispatch event."
+      switch "--quiet",
+        description: "Print only the logs or error if occurred, nothing more."
+    end
+  end
+
+  def print_failed_logs(file)
+    # Border lines indexes
+    brew_index = -1
+    failed_index = -1
+
+    # Find indexes of border lines
+    content = File.read(file).lines
+    content.each_with_index do |line, index|
+      if /.*==> .*FAILED.*/.match?(line)
+        failed_index = index
+        break
+      elsif /.*==>.* .*brew .+/.match?(line)
+        brew_index = index
+      end
+    end
+
+    # One of the border lines weren't found
+    return if brew_index.negative? || failed_index.negative?
+
+    # Remove timestamp prefix on every line
+    content.map! do |line|
+      line.split(" ")[1..-1]&.join(" ")
+    end
+
+    # Print only interesting lines
+    puts content[brew_index..failed_index]
+  end
+
+  def fetch_failed_logs
+    fetch_failed_logs_args.parse
+
+    raise FormulaUnspecifiedError if Homebrew.args.named.empty?
+
+    formula = Homebrew.args.resolved_formulae.first
+    event = args.dispatched? ? "repository_dispatch" : "pull_request"
+    repo = "Homebrew/linuxbrew-core"
+
+    # First get latest workflow runs
+    url = "https://api.github.com/repos/#{repo}/actions/runs?status=failure&event=#{event}"
+    response = GitHub.open_api(url, request_method: :GET, scopes: ["repo"])
+    workflow_runs = response["workflow_runs"]
+
+    # Then iterate over them and find the matching one...
+    workflow_run = workflow_runs.find do |run|
+      # If the workflow run was triggered by a repository dispatch event, then
+      # check if any step name in all its jobs is equal to formula
+      if run["event"] == "repository_dispatch"
+        url = run["jobs_url"]
+        response = GitHub.open_api(url, request_method: :GET, scopes: ["repo"])
+        jobs = response["jobs"]
+        jobs.find do |job|
+          steps = job["steps"]
+          steps.find do |step|
+            step["name"].match(formula.name)
+          end
+        end
+      # If the workflow run was triggered by a pull request event, then
+      # fetch the head commit, determine which file changed and
+      # check if equal to formula
+      elsif run["event"] == "pull_request"
+        url = "https://api.github.com/repos/#{repo}/commits/#{run["head_sha"]}"
+        response = GitHub.open_api(url, request_method: :GET, scopes: ["repo"])
+        commit_files = response["files"].map { |f| f["filename"] }
+        commit_files.find do |file|
+          file[%r{Formula/(.+)\.rb}, 1] == formula.name
+        end
+      end
+    end
+
+    odie "No workflow run matching the criteria was found" unless workflow_run
+
+    unless args.quiet?
+      oh1 "Workflow details:"
+      puts JSON.pretty_generate(workflow_run.slice("id", "event", "status", "conclusion", "created_at"))
+    end
+
+    # Download logs zipball,
+    # create a temporary directory,
+    # extract it there and print
+    url = workflow_run["logs_url"]
+    response = GitHub.open_api(url, request_method: :GET, scopes: ["repo"], parse_json: false)
+    Dir.mktmpdir do |tmpdir|
+      file = "#{tmpdir}/logs.zip"
+      File.write(file, response)
+      safe_system("unzip", "-qq", "-d", tmpdir, file)
+      Dir["#{tmpdir}/*.txt"].each do |f|
+        print_failed_logs f
+      end
+    end
+  end
+end


### PR DESCRIPTION
This script fetches latest build failures logs from GitHub Actions API for given formula.

Supports `repository_dispatch` (`--dispatched` option) and `pull_request` events.

Example:

```
➜  ~  brew fetch-failed-logs imapsync --dispatched
==> Workflow run id: 67726873
==> brew test imapsync --verbose
Testing imapsync
==> /home/linuxbrew/.linuxbrew/Cellar/imapsync/1.977/bin/imapsync --dry
Can't locate Socket6.pm in @INC (you may need to install the Socket6 module) (@INC contains: /home/linuxbrew/.linuxbrew/Cellar/imapsync/1.977/libexec/lib/perl5 /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /home/linuxbrew/.linuxbrew/Cellar/imapsync/1.977/libexec/lib/perl5/IO/Socket/INET6.pm line 40.
BEGIN failed--compilation aborted at /home/linuxbrew/.linuxbrew/Cellar/imapsync/1.977/libexec/lib/perl5/IO/Socket/INET6.pm line 40.
Compilation failed in require at /home/linuxbrew/.linuxbrew/Cellar/imapsync/1.977/libexec/bin/imapsync line 865.
BEGIN failed--compilation aborted at /home/linuxbrew/.linuxbrew/Cellar/imapsync/1.977/libexec/bin/imapsync line 865.
Error: imapsync: failed
An exception occurred within a child process:
Test::Unit::AssertionFailedError: </1\.977/> was expected to be =~
<"">.
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:55:in `block in assert_block'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:1631:in `_wrap_assertion'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:53:in `assert_block'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:543:in `block in assert_match'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:1636:in `_wrap_assertion'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:533:in `assert_match'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/imapsync.rb:164:in `block in <class:Imapsync>'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1777:in `block (3 levels) in run_test'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils.rb:478:in `with_env'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1776:in `block (2 levels) in run_test'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:867:in `with_logging'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1775:in `block in run_test'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2020:in `block in mktemp'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/mktemp.rb:57:in `block in run'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/mktemp.rb:57:in `chdir'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/mktemp.rb:57:in `run'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2019:in `mktemp'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1769:in `run_test'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test.rb:35:in `block in <main>'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test.rb:34:in `<main>'
==> FAILED
```