### PR TITLE
fetch-failed-logs.rb: `args` -> `Homebrew.args`

### DIFF
--- a/cmd/fetch-failed-logs.rb
+++ b/cmd/fetch-failed-logs.rb
@@ -54,7 +54,7 @@ module Homebrew
     raise FormulaUnspecifiedError if Homebrew.args.named.empty?
 
     formula = Homebrew.args.resolved_formulae.first
-    event = args.dispatched? ? "repository_dispatch" : "pull_request"
+    event = Homebrew.args.dispatched? ? "repository_dispatch" : "pull_request"
     repo = "Homebrew/linuxbrew-core"
 
     # First get latest workflow runs
@@ -91,7 +91,7 @@ module Homebrew
 
     odie "No workflow run matching the criteria was found" unless workflow_run
 
-    unless args.quiet?
+    unless Homebrew.args.quiet?
       oh1 "Workflow details:"
       puts JSON.pretty_generate(workflow_run.slice("id", "event", "status", "conclusion", "created_at"))
     end


### PR DESCRIPTION
I believe it should be `Homebrew.args` instead of plain `args` ... no?