### PR TITLE
README.md: standardize + add fetch_failed_logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,25 @@
 
 Tools for Homebrew on Linux developers
 
-+ **announce**: Create an announcement for new formulae that could be e.g., posted to Twitter.
-+ **check-for-deleted-upstream-core-formulae**: Checks for formulae in linuxbrew-core that have been deleted from homebrew-core.
-+ **find-formulae-to-bottle**: For a merge commit, generate a list of conflicting formulae.
-+ **find-not-bottled**: Search for formulae in linuxbrew-core that do not have a bottle for Linux.
-+ **merge-homebrew**: Merge a tap Homebrew/repo into Linuxbrew/repo.
-+ **migrate-formula**: Migrates a formula to a new tap and opens the appropriate pull requests.
-+ **pull-macos**: When running Homebrew on Linux, pull a bottle for macOS.
-+ **request-bottle**: Triggers a Linux bottle build for a formula using GitHub Actions.
-+ **test-bot-docker**: Runs `brew test-bot` for a formula in a Docker container.
++ **announce**: Create an announcement for new formulae.
++ **check-for-deleted-upstream-core-formulae**: Check for formulae in [Homebrew/linuxbrew-core][linuxbrew-core] that have been deleted from homebrew-core.
++ **fetch-failed-logs**: Fetch failed part of a CI run for the specified formula.
++ **find-formulae-to-bottle**: Generate a list of formulae that encountered a conflict in the specified  merge.
++ **find-not-bottled**: Search for formulae in [Homebrew/linuxbrew-core][linuxbrew-core] that do not have a bottle for Linux.
++ **merge-homebrew**: Merge Homebrew/repo into Linuxbrew/repo.
++ **migrate-formula**: Migrate a formula to a new tap and open appropriate pull requests.
++ **pull-macos**: Pull a bottle for macOS (when running Homebrew on Linux).
++ **request-bottle**: Trigger a GitHub Actions CI to build Linux bottle for the specified a formula(e).
++ **test-bot-docker**: Run `brew test-bot` in a Docker container.
 
 ## Installation
 
-```
+```sh
 brew tap homebrew/linux-dev
 ```
 
 ## Adding new tools
 
 Read the ["External Commands" documentation](https://docs.brew.sh/External-Commands) to see how to create Homebrew external commands.
+
+[linuxbrew-core]: https://github.com/Homebrew/linuxbrew-core


### PR DESCRIPTION
- Begin descriptions with a verb in Infinitive form (without "to").
- add `linuxbrew-core` link
- add description for `fetch-failed-logs` (CC @dawidd6)