### PR TITLE
fetch-failed-logs: multiple improvements

### DIFF
--- a/cmd/fetch-failed-logs.rb
+++ b/cmd/fetch-failed-logs.rb
@@ -62,7 +62,7 @@ module Homebrew
     repo = Tap.fetch(tap_name).full_name
 
     # First get latest workflow runs
-    url = "https://api.github.com/repos/#{repo}/actions/runs?status=failure&event=#{event}"
+    url = "https://api.github.com/repos/#{repo}/actions/runs?status=failure&event=#{event}&per_page=100"
     response = GitHub.open_api(url, request_method: :GET, scopes: ["repo"])
     workflow_runs = response["workflow_runs"]
 

--- a/cmd/fetch-failed-logs.rb
+++ b/cmd/fetch-failed-logs.rb
@@ -87,6 +87,7 @@ module Homebrew
         url = "https://api.github.com/repos/#{repo}/commits/#{run["head_sha"]}"
         response = GitHub.open_api(url, request_method: :GET, scopes: ["repo"])
         commit_files = response["files"].map { |f| f["filename"] }
+        odebug "Run ##{run["id"]} - #{commit_files.join ", "}"
         commit_files.find do |file|
           file[%r{Formula/(.+)\.rb}, 1] == formula.name
         end

--- a/cmd/fetch-failed-logs.rb
+++ b/cmd/fetch-failed-logs.rb
@@ -58,7 +58,7 @@ module Homebrew
 
     formula = Homebrew.args.resolved_formulae.first
     event = Homebrew.args.dispatched? ? "repository_dispatch" : "pull_request"
-    tap_name = Homebrew.args.tap || "homebrew/core"
+    tap_name = Homebrew.args.tap || CoreTap.instance.name
     repo = Tap.fetch(tap_name).full_name
 
     # First get latest workflow runs

--- a/cmd/fetch-failed-logs.rb
+++ b/cmd/fetch-failed-logs.rb
@@ -19,6 +19,9 @@ module Homebrew
         description: "Search through workflow runs triggered by repository_dispatch event."
       switch "--quiet",
         description: "Print only the logs or error if occurred, nothing more."
+      switch :verbose
+      switch :debug
+      named 1
     end
   end
 
@@ -52,8 +55,6 @@ module Homebrew
 
   def fetch_failed_logs
     fetch_failed_logs_args.parse
-
-    raise FormulaUnspecifiedError if Homebrew.args.named.empty?
 
     formula = Homebrew.args.resolved_formulae.first
     event = Homebrew.args.dispatched? ? "repository_dispatch" : "pull_request"


### PR DESCRIPTION
I've broken this up into several commits, but these were originally written all at once so the individual commits might not be testable on their own.

The main new features are:

* permit keeping log files around with `--keep-tmp`
* fetch multiple failures per log file
* strip out ANSI control codes if stdout isn't a terminal (also respecting `HOMEBREW_COLOR` and `HOMEBREW_NO_COLOR`)
* optional markdown output (which also strips ansi control codes) so you can `brew fetch-failed-logs <formula> | pbcopy` then paste it into a github issue.... or for actions to do something similar ;) 
