### PR TITLE
merge-homebrew: autofix conflicts in bottle blocks

### DIFF
--- a/cmd/merge-homebrew.rb
+++ b/cmd/merge-homebrew.rb
@@ -4,6 +4,10 @@ require "date"
 module Homebrew
   module_function
 
+  CONFLICT_START = /^<{7,} /.freeze
+  CONFLICT_BOUNDARY = /^={7,}/.freeze
+  CONFLICT_END = /^>{7,} /.freeze
+
   def merge_homebrew_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
@@ -65,22 +69,22 @@ module Homebrew
 
   def fix_bottle_merge_conflicts!(file)
     # rubocop:disable Style/DisableCopsWithinSourceCodeDirective, Lint/FlipFlop
-    new_contents = File.read(file).lines.map do |l|
-      if l == "  bottle do\n" .. l == "  end\n"
+    new_contents = File.read(file).lines.map do |line|
+      if line == "  bottle do\n" .. line == "  end\n"
         # Now inside a bottle block.
-        if l == "<<<<<<< HEAD\n" .. l == ">>>>>>> homebrew/master\n"
+        if CONFLICT_START.match?(line) .. CONFLICT_END.match?(line)
           # Now inside a merge conflict.
           # Skip top part of merge conflict.
-          next if l == "<<<<<<< HEAD\n" .. l == "=======\n"
+          next if CONFLICT_START.match?(line) .. CONFLICT_BOUNDARY.match?(line)
 
           # Remove `cellar :any`, etc. lines.
-          next if l.include? "cellar"
+          next if line.include? "cellar"
 
           # Remove trailing bit of merge conflict.
-          next if l == ">>>>>>> homebrew/master\n"
+          next if CONFLICT_END.match?(line)
         end
       end
-      l
+      line
     end.compact.join
     # rubocop:enable Lint/FlipFlop, Style/DisableCopsWithinSourceCodeDirective
 

--- a/cmd/merge-homebrew.rb
+++ b/cmd/merge-homebrew.rb
@@ -63,9 +63,31 @@ module Homebrew
     homebrew_commits.each { |sha1| git_merge_commit sha1, fast_forward: fast_forward }
   end
 
+  def fix_bottle_merge_conflicts!(file)
+    # rubocop:disable Style/DisableCopsWithinSourceCodeDirective, Lint/FlipFlop
+    new_contents = File.read(file).lines.map do |l|
+      if l == "  bottle do\n" .. l == "  end\n"
+        # Now inside a bottle block.
+        if l == "<<<<<<< HEAD\n" .. l == ">>>>>>> homebrew/master\n"
+          # Now inside a merge conflict.
+          # Skip top part of merge conflict.
+          next if l == "<<<<<<< HEAD\n" .. l == "=======\n"
+          # Remove trailing bit of merge conflict.
+          next if l == ">>>>>>> homebrew/master\n"
+        end
+      end
+      l
+    end.compact.join
+    # rubocop:enable Lint/FlipFlop, Style/DisableCopsWithinSourceCodeDirective
+
+    File.atomic_write(file) { |f| f.write(new_contents) }
+  end
+
   def resolve_conflicts
     conflicts = Utils.popen_read(git, "diff", "--name-only", "--diff-filter=U").split
     return conflicts if conflicts.empty?
+
+    conflicts.each { |f| fix_bottle_merge_conflicts! f }
 
     oh1 "Conflicts"
     puts conflicts.join(" ")

--- a/cmd/merge-homebrew.rb
+++ b/cmd/merge-homebrew.rb
@@ -72,6 +72,10 @@ module Homebrew
           # Now inside a merge conflict.
           # Skip top part of merge conflict.
           next if l == "<<<<<<< HEAD\n" .. l == "=======\n"
+
+          # Remove `cellar :any`, etc. lines.
+          next if l.include? "cellar"
+
           # Remove trailing bit of merge conflict.
           next if l == ">>>>>>> homebrew/master\n"
         end

--- a/cmd/merge-homebrew.rb
+++ b/cmd/merge-homebrew.rb
@@ -33,7 +33,10 @@ module Homebrew
     return @editor if @editor
 
     @editor = [which_editor]
-    @editor += ["-f", "+/^<<<<"] if %w[gvim nvim vim vi].include? File.basename(editor[0])
+    ed = File.basename @editor[0]
+
+    @editor += ["-c", "silent!  /^<<<<<<<\\|=======\\|>>>>>>>"] if %w[mvim gvim nvim vim].include? ed
+    @editor << "--nofork" if %w[mvim gvim].include? ed
     @editor
   end
 


### PR DESCRIPTION
When merge conflicts are detected within `bottle do` blocks, this pull request will automatically pick the upstream side of the merge conflict. It leaves merge conflicts found elsewhere in the file to the maintainer. Because the file is marked as a merge conflict, it should still show the file to the maintainer, so it's not completely automatic and there's another human check to make sure that nothing evil has happened.

Note that this uses the Ruby flip-flop operator. Even though RuboCop would prefer that we avoid this operator, there's no cleaner way to operate over a range of lines without building some ugly state machine, especially given that we have nested flip-flops. Those RuboCop warnings are also silenced here.