### PR TITLE
merge-homebrew: use named_args max

### DIFF
--- a/cmd/merge-homebrew.rb
+++ b/cmd/merge-homebrew.rb
@@ -23,7 +23,7 @@ module Homebrew
       switch "--skip-style",
              description: "Skip running `brew style` on merged formulae."
       conflicts "--core", "--tap"
-      max_named 1
+      named_args max: 1
     end
   end
 


### PR DESCRIPTION
Fixes:
Error: Calling `max_named` is deprecated! Use `named_args max:` instead.
Please report this issue to the homebrew/linux-dev tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-linux-dev/cmd/merge-homebrew.rb:26