### PR TITLE
fetch-failed-logs: fix style

### DIFF
--- a/cmd/fetch-failed-logs.rb
+++ b/cmd/fetch-failed-logs.rb
@@ -54,7 +54,7 @@ module Homebrew
     strip_ansi = args.markdown? || !Tty.color?
     content.map! do |line|
       line = Tty.strip_ansi(line) if strip_ansi
-      line.split(" ")[1..]&.join(" ")
+      line.split[1..]&.join(" ")
     end
 
     # Print only interesting lines


### PR DESCRIPTION
Fixes:
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-linux-dev/cmd/fetch-failed-logs.rb:57:7: C: [Correctable] Argument " " is redundant because it is implied by default.
line.split(" ")[1..]&.join(" ")