### PR TITLE
cmd/request-bottle: Better error message for no GitHub API token envvar

### DIFF
--- a/cmd/request-bottle.rb
+++ b/cmd/request-bottle.rb
@@ -62,6 +62,10 @@ module Homebrew
     odie "User not specified" if user.empty?
     odie "Email not specified" if email.empty?
 
+    if !ENV["HOMEBREW_GITHUB_API_TOKEN"]
+      odie "`HOMEBREW_GITHUB_API_TOKEN` envvar not present. Generate a GitHub API token with `gist, read:org, public_repo and workflow` scopes at https://github.com/settings/tokens."
+    end
+
     args.named.to_resolved_formulae.each do |formula|
       # Always dispatch core formulae against Homebrew/linuxbrew-core,
       # even on macOS.


### PR DESCRIPTION
- Previously, for users who tried to run this without `HOMEBREW_GITHUB_API_TOKEN` set, we'd return the GitHub API error "Not Found" - the least helpful error message.
- This detects if a user doesn't have `HOMEBREW_GITHUB_API_TOKEN` and prompts them to create one with the required scopes in order for this command to succeed in the future.

Inspired by @danielnachun's question in Slack last night.
