### PR TITLE
Update GitHub API usage

### DIFF
--- a/cmd/request-bottle.rb
+++ b/cmd/request-bottle.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "cli/parser"
-require "utils/github"
+require "utils/github/api"
 
 module Homebrew
   module_function
@@ -82,7 +82,7 @@ module Homebrew
       data = { event_type: event_name, client_payload: payload }
       ohai "Dispatching request to #{remote} for #{formula}"
       url = "https://api.github.com/repos/#{remote}/dispatches"
-      GitHub.open_api(url, data: data, request_method: :POST, scopes: ["repo"])
+      GitHub::API.open_rest(url, data: data, request_method: :POST, scopes: ["repo"])
     end
   end
 end


### PR DESCRIPTION
This PR updates the usage of Homebrew's GitHub API module as a consequence of Homebrew/brew#10626. Calls to `GitHub.open_api` (now a deprecated wrapper method) have been replaced with `GitHub::API.open_rest`.