### PR TITLE
request-bottle: fix deprecation

### DIFF
--- a/cmd/request-bottle.rb
+++ b/cmd/request-bottle.rb
@@ -82,7 +82,7 @@ module Homebrew
       data = { event_type: event_name, client_payload: payload }
       ohai "Dispatching request to #{remote} for #{formula}"
       url = "https://api.github.com/repos/#{remote}/dispatches"
-      GitHub.open_api(url, data: data, request_method: :POST, scopes: ["repo"])
+      GitHub::API.open_rest(url, data: data, request_method: :POST, scopes: ["repo"])
     end
   end
 end


### PR DESCRIPTION
Fixes:
Error: Calling GitHub.open_api is deprecated! Use GitHub::API.open_rest instead.