### PR TITLE
cmds: use max_named

### DIFF
--- a/cmd/check-for-deleted-upstream-core-formulae.rb
+++ b/cmd/check-for-deleted-upstream-core-formulae.rb
@@ -18,7 +18,7 @@ module Homebrew
              description: "Full path to the Homebrew/linuxbrew-core repo on disk."
       flag   "--homebrew-repo-dir=",
              description: "Full path to the Homebrew/homebrew-core repo on disk."
-      max_named 0
+      named_args max: 0
     end
   end
 

--- a/cmd/find-formulae-to-bottle.rb
+++ b/cmd/find-formulae-to-bottle.rb
@@ -16,7 +16,7 @@ module Homebrew
       EOS
       switch "-v", "--verbose",
              description: "Print additional information, e.g. if a formula already has a bottle PR open."
-      max_named 0
+      named_args max: 0
     end
   end
 

--- a/cmd/find-not-bottled.rb
+++ b/cmd/find-not-bottled.rb
@@ -18,7 +18,7 @@ module Homebrew
              description: "Match only formulae that do not contain the given pattern."
       flag   "--tap=",
              description: "Specify a tap rather than the default #{CoreTap.instance.name}."
-      max_named 0
+      named_args max: 0
     end
   end
 


### PR DESCRIPTION
Fixes:
Calling `max_named` is disabled! Use `named_args max:` instead.