### PR TITLE
merge-homebrew: delete homebrew-core bottles on merge

### DIFF
--- a/cmd/merge-homebrew.rb
+++ b/cmd/merge-homebrew.rb
@@ -142,6 +142,7 @@ module Homebrew
       modified_files = modified_files_after_merge
       modified_files.each do |file_name|
         delete_all_bottle_block(file_name)
+        delete_homebrew_core_bottle(file_name)
       end
       safe_system git, "add", "--", *modified_files unless modified_files.empty?
       safe_system git, "commit", "--amend", "--no-edit" unless modified_files.empty?
@@ -170,6 +171,15 @@ module Homebrew
 
       hub_pull_request branch, message, args: args
     end
+  end
+
+  def delete_homebrew_core_bottle(file_name)
+    content = File.readlines(file_name)
+    return if content.grep(/x86_64_linux:/).size.positive? && content.grep(/" # linuxbrew-core/).size.positive?
+
+    text = File.read(file_name)
+    new_text = text.lines.reject { |x| x.include? "x86_64_linux:" }.join
+    File.open(file_name, "w") { |file| file.puts new_text }
   end
 
   def delete_all_bottle_block(file_name)


### PR DESCRIPTION
Right now I am adding a comment after each linuxbrew-core bottle with:
`ls | xargs grep -L "# linuxbrew-core" | xargs sed -i '' 's/.*x86_64_linux.*/& # linuxbrew-core/g' ; git add . ; git commit -m "formulae: add comment to bottle line to generate conflicts on next merge"`

after each merge. This allows to get rid of homebrew-core linux formulae when merging.