### PR TITLE
Dockerfile: add bzip2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
        autoconf \
        automake \
        bison \
+       bzip2 \
        ca-certificates \
        curl \
        file \


### PR DESCRIPTION
This was needed for https://github.com/Homebrew/homebrew-portable-ruby/pull/127 so I thought it might be useful here too.